### PR TITLE
Add reviews endpoint

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -326,6 +326,18 @@ var GooglePlay = (function GooglePlay(username, password, androidId, useCache, d
     });
   }
 
+  function getReviews(pkg, nbResults, offset) {
+    if (nbResults > 20) {
+      nbResults = 20;
+    }
+    var query = {doc: pkg, c: 3, n: nbResults || 20, o: offset || 0};
+    return executeRequestApi('rev', query).then(function (res) {
+      assert(res.payload.reviewResponse, "expected response");
+      assert(res.payload.reviewResponse.getResponse, "expected getResponse");
+      return res.payload.reviewResponse.getResponse;
+    });
+  }
+
 
   /**
    * Get URL and cookie info for downloading a file from Google.
@@ -429,6 +441,9 @@ var GooglePlay = (function GooglePlay(username, password, androidId, useCache, d
         offset = undefined;
       }
       return searchQuery(term, nResults, offset).nodeify(cb);
+    },
+    reviews: function reviews(pkg, nResults, offset, cb) {
+      return getReviews(pkg, nResults, offset).nodeify(cb);
     },
     cachedKeys: cachedKeys,
     invalidateCache: invalidateCache

--- a/test/reviews.test.js
+++ b/test/reviews.test.js
@@ -1,0 +1,12 @@
+var api = require('./api');
+
+var test = require('tape');
+
+test('review api', function (t) {
+  api.reviews('com.viber.voip', 20, 20, function (err, res) {
+    t.notOk(err, 'no error');
+    t.ok(res, 'returned results');
+    t.end();
+  });
+});
+


### PR DESCRIPTION
App reviews are delivered in the default locale which might fallback
to English. It is only possible to query for 20 reviews at once.