### PR TITLE
Only activate debug mode if process.env.DEBUG contains "gp:api".

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -36,7 +36,7 @@ var LoginError  = require('./errors').LoginError;
 var GooglePlay = (function GooglePlay(username, password, androidId, useCache, debug, requestsDefaultParams) {
   // default for args:
   androidId = androidId || null;
-  debug = (!!process.env.DEBUG) || debug === true;
+  debug = /gp:api/.test(process.env.DEBUG) || debug === true;
 
   var USE_CACHE = (useCache === true);
   var authToken;


### PR DESCRIPTION
We're using sails.js, and even in production there's still some other DEBUG values set (so process.env.DEBUG is truthy). This PR avoids polluting production logs with HTTP request debugging output.