### PR TITLE
Assert for "application/protobuf"

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -217,7 +217,7 @@ var GooglePlay = (function GooglePlay(username, password, androidId, useCache, _
           return handleErr(res, body);
         }
         assert(res.statusCode === 200, 'http status code');
-        assert(res.headers['content-type'] === 'application/x-gzip', 'not application/x-gzip response');
+        assert(res.headers['content-type'] === 'application/protobuf', 'not application/protobuf response');
         assert(Buffer.isBuffer(body), 'expect Buffer body');
         return body;
       });


### PR DESCRIPTION
GP no longer appears to send ```application/x-gzip``` for ```content-type```. Can somebody re-confirm ?