### PR TITLE
Use request instance for each api instance

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,7 +1,7 @@
 'use strict';
 const Promise = require('bluebird');
 const ProtoBuf = require('protobufjs');
-let request = Promise.promisifyAll(require('request'), { multiArgs: true });
+const defaultRequest = Promise.promisifyAll(require('request'), { multiArgs: true });
 const util = require('util');
 const fmt = util.format;
 const _ = require('lodash');
@@ -54,7 +54,7 @@ const DEFAULTS = {
  * @return {type}
  */
 const GooglePlay = function GooglePlay (username, password, androidId, useCache, _debug, requestsDefaultParams) {
-  let opts;
+  let opts, request;
   /**
    * In case that username is an object, it's in fact an options parameter so
    * we treat it as such
@@ -82,11 +82,14 @@ const GooglePlay = function GooglePlay (username, password, androidId, useCache,
     require('request-debug')(request);
   }
 
+  //default paramenters should be applied to every google play instance individually
   if (opts.requestsDefaultParams) {
     request = Promise.promisifyAll(
       require('request').defaults(opts.requestsDefaultParams),
       { multiArgs: true }
     );
+  } else {
+    request = defaultRequest;
   }
 
   let DEVICE_COUNTRY, OPERATOR_COUNTRY, LOGIN_LANGUAGE;


### PR DESCRIPTION
Right now there is global request object and any request defaults will be overwritten when creating different instance