### PR TITLE
added appDeliveryData to getCompleteDownloadInfo

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -449,7 +449,7 @@ const GooglePlay = function GooglePlay (opts) {
         assert(res.downloadAuthCookie, 'require downloadAuthCookie');
         const url = res.downloadUrl;
         const cookieJar = _prepCookies(url, res.downloadAuthCookie);
-        return { url: url, jar: cookieJar, headers: headers };
+        return { url: url, jar: cookieJar, headers: headers, appDeliveryData : res };
       });
   }
 


### PR DESCRIPTION
Hi,
first off, great job on version 4! 
customising the useragent is a great addition and my team will defiantly use it.

this PR will return appDeliveryData with the url and cookie jar so we can use it to further enrich our apk data.
i rather not call `Api.deliveryData` since it will trigger another API call - and we need to reduce the number of calls.

if you think we should implement a memoization for that request instead of adding that info to this function let me know.
Thanks!