### PR TITLE
Remove assert from google change in resp

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -242,7 +242,7 @@ const GooglePlay = function GooglePlay (opts) {
           return handleErr(res, body);
         }
         assert(res.statusCode === 200, 'http status code');
-        assert(res.headers['content-type'] === 'application/protobuf', 'not application/protobuf response');
+        // assert(res.headers['content-type'] === 'application/protobuf', 'not application/protobuf response');
         assert(Buffer.isBuffer(body), 'expect Buffer body');
         return body;
       });


### PR DESCRIPTION
- Google seems to have changed the response header
- removing the assert seems to unbreak the library
- Would like to see what they are sending now