### PR TITLE
change sdkVersion from string to int

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -32,7 +32,7 @@ const DEFAULTS = {
   language: 'en_US',
   useCache: false,
   debug: false,
-  sdkVersion: '23',
+  sdkVersion: 23,
   countryCode: 'us',
   apiUserAgent: USER_AGENT,
   downloadUserAgent: DOWNLOAD_MANAGER_USER_AGENT,


### PR DESCRIPTION
Fix for the login error: https://github.com/dweinstein/node-google-play/issues/103