### PR TITLE
Fix UNKNOWN_ERR on login

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -122,8 +122,7 @@ const GooglePlay = function GooglePlay (opts) {
       'app': _opts.androidVending,
       'device_country': _opts.countryCode,
       'operatorCountry': _opts.countryCode,
-      'lang': _opts.countryCode,
-      'sdk_version': _opts.sdkVersion
+      'lang': _opts.countryCode
     };
 
     return _request.postAsync({url: _opts.loginUrl, gzip: true, json: false, form: body})


### PR DESCRIPTION
Fixes #107 
Seems like google identifies that the call isn't coming from a client by  examining the payload.
`sdk_version` is a parameter sent by the `gpapi` package but not by the client.
removing the `sdk_version` parameter from the login request solves the problem - after removing it the login ends successfully.